### PR TITLE
Fix typo in interface

### DIFF
--- a/src/types/awair/latestData.ts
+++ b/src/types/awair/latestData.ts
@@ -2,11 +2,11 @@ export interface AwairLatestData {
   timestamp: string,
   score: number,
   sensors: {
-    camp: string,
+    comp: string,
     value: number
   }[],
   indices: {
-    camp: string,
+    comp: string,
     value: number
   }[]
 }


### PR DESCRIPTION
The current `latestData` interface has some typos in the name of some fields. 
This PR fix that to same you some minutes (or hours) looking for a missing field 😃 

![image](https://user-images.githubusercontent.com/4540919/161280904-6129de3e-4921-49b4-913e-30e85f7665fc.png)


https://docs.developer.getawair.com/#69256a45-1c1b-4d35-b1e8-79d8fc3f7c0c
