### PR TITLE
Add author field to package.json to allow for windows builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "awair-uploader",
+  "author": {
+    "name": "PW Community"
+  },
   "productName": "awair-uploader",
   "version": "0.0.1",
   "description": "An Awair Element data uploader",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7945469/161108914-4c4fa6ac-c436-45f6-bada-5d1bf6224e64.png)

Include the author field in package.json (error occurs when running npm run make)