### PR TITLE
Fix for security policy, enable devtools menu for debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
           "@electron-forge/plugin-webpack",
           {
             "mainConfig": "./webpack.main.config.js",
-            "devContentSecurityPolicy": "connect-src 'self' http://wearableapi.test.planetwatch.io http://login.planetwatch.io https://developer-apis.awair.is 'unsafe-eval'",
+            "devContentSecurityPolicy": "connect-src 'self' http://wearableapi.planetwatch.io http://login.planetwatch.io https://developer-apis.awair.is 'unsafe-eval'",
             "renderer": {
               "config": "./webpack.renderer.config.js",
               "entryPoints": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ const createWindow = (): void => {
     height: 600 * 1.2,
     width: 800 * 1.2,
     webPreferences: {
-      devTools: false
+      devTools: true
     }
   });
 


### PR DESCRIPTION
Enable devtools so we can help people debug errors, also fix devContentSecurityPolicy (currently set to "test")